### PR TITLE
[FIX]: user can only upload jpeg or png files

### DIFF
--- a/src/views/NewBillUI.js
+++ b/src/views/NewBillUI.js
@@ -55,7 +55,7 @@ export default () => {
                   </div>
                   <div class="col-half">
                     <label for="file" class="bold-label">Justificatif</label>
-                    <input required type="file" class="form-control blue-border" data-testid="file" />
+                    <input required type="file" class="form-control blue-border" data-testid="file" accept="image/jpeg,image/png" />
                   </div>
                 </div>
             </div>


### PR DESCRIPTION
Allow only image/jpeg, image/png as valid file type in NewBillUI.

close #3 